### PR TITLE
Add GitHub Actions to run scripts and tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements.test.txt
+
+      - name: Run make_dist.py
+        run: python scripts/make_dist.py
+
+      - name: Run validator.py
+        run: python scripts/validator.py
+
+      - name: Run tests
+        run: tests/run_tests.sh


### PR DESCRIPTION
Add GitHub Actions workflow to run scripts and tests on CI.

* Add `.github/workflows/ci.yml` to define the CI workflow
* Trigger the workflow on push and pull request events for the `main` branch
* Use a Python 3.8 environment and install dependencies from `requirements.txt` and `requirements.test.txt`
* Run `scripts/make_dist.py`, `scripts/validator.py`, and `tests/run_tests.sh` in sequence

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bscholer/ntrip-catalog/pull/1?shareId=6e3dfdae-fcd7-43f9-a29e-06d09d1fef5d).